### PR TITLE
Update conda_dependencies.yml

### DIFF
--- a/aml_config/conda_dependencies.yml
+++ b/aml_config/conda_dependencies.yml
@@ -28,4 +28,5 @@ dependencies:
     # Helper utilities for dealing with Azure ML Workbench Assets.
     - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.assets-1.0.0-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
     - matplotlib
-    - ggplot 
+    - ggplot
+    - pandas==0.21.0


### PR DESCRIPTION
Fixes ggplot import failure due to breaking changes starting .22 in move of Timestamp from pandas pandas.libs  to pandas._libs.lib

https://github.com/yhat/ggpy/issues/618
https://pandas.pydata.org/pandas-docs/version/0.22.0/whatsnew.htmltimes